### PR TITLE
Add missing serialVersionUID to subclasses of SearchListener

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/FitnessLogger.java
+++ b/client/src/main/java/org/evosuite/coverage/FitnessLogger.java
@@ -44,6 +44,8 @@ public class FitnessLogger<T extends Chromosome<T>> implements SearchListener<T>
 
 	private static final Logger logger = LoggerFactory.getLogger(FitnessLogger.class);
 
+	private static final long serialVersionUID = 1914403470617343821L;
+
 	private final List<Integer> evaluations_history;
 	private final List<Long> statements_history;
 	private final List<Double> fitness_history;

--- a/client/src/main/java/org/evosuite/ga/stoppingconditions/RMIStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/ga/stoppingconditions/RMIStoppingCondition.java
@@ -28,6 +28,8 @@ import org.evosuite.ga.metaheuristics.GeneticAlgorithm;
  */
 public class RMIStoppingCondition<T extends Chromosome<T>> implements StoppingCondition<T> {
 
+	private static final long serialVersionUID = 3073266508021896691L;
+
 	private static RMIStoppingCondition<?> instance = null;
 
 	private boolean isStopped = false;

--- a/client/src/main/java/org/evosuite/ga/stoppingconditions/SocketStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/ga/stoppingconditions/SocketStoppingCondition.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
  */
 public class SocketStoppingCondition<T extends Chromosome<T>> implements StoppingCondition<T> {
 
+	private static final long serialVersionUID = -8260473153410290373L;
+
 	private volatile boolean interrupted;
 
 	private static final Logger logger = LoggerFactory.getLogger(SocketStoppingCondition.class);

--- a/client/src/main/java/org/evosuite/novelty/SuiteFitnessEvaluationListener.java
+++ b/client/src/main/java/org/evosuite/novelty/SuiteFitnessEvaluationListener.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public class SuiteFitnessEvaluationListener implements SearchListener<TestChromosome> {
 
+    private static final long serialVersionUID = 3871230464292232335L;
+
     private final List<TestSuiteFitnessFunction> fitnessFunctions;
 
     public SuiteFitnessEvaluationListener(List<TestSuiteFitnessFunction> fitnessFunctions) {

--- a/client/src/main/java/org/evosuite/seeding/TestCaseRecycler.java
+++ b/client/src/main/java/org/evosuite/seeding/TestCaseRecycler.java
@@ -50,6 +50,8 @@ import org.evosuite.testsuite.TestSuiteChromosome;
  */
 public final class TestCaseRecycler<T extends Chromosome<T>> implements SearchListener<T> {
 
+	private static final long serialVersionUID = -2372656982678139994L;
+
 	private static TestCaseRecycler<?> instance;
 
 	private final Set<TestCase> testPool;

--- a/client/src/main/java/org/evosuite/statistics/StatisticsListener.java
+++ b/client/src/main/java/org/evosuite/statistics/StatisticsListener.java
@@ -41,6 +41,8 @@ import org.evosuite.testsuite.TestSuiteChromosome;
  */
 public class StatisticsListener<T extends Chromosome<T>> implements SearchListener<T> {
 
+	private static final long serialVersionUID = -8229756367168023616L;
+
 	private final BlockingQueue<T> individuals;
 	
 	private volatile boolean done;

--- a/client/src/main/java/org/evosuite/testcase/localsearch/BranchCoverageMap.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/BranchCoverageMap.java
@@ -32,6 +32,8 @@ import org.evosuite.testsuite.TestSuiteChromosome;
 
 public class BranchCoverageMap implements SearchListener<TestSuiteChromosome> {
 
+	private static final long serialVersionUID = -3498997999289782541L;
+
 	public static BranchCoverageMap instance = null;
 	
 	private Map<Integer, TestCase> coveredTrueBranches;

--- a/client/src/main/java/org/evosuite/testsuite/similarity/DiversityObserver.java
+++ b/client/src/main/java/org/evosuite/testsuite/similarity/DiversityObserver.java
@@ -39,6 +39,8 @@ public class DiversityObserver implements SearchListener<TestSuiteChromosome> {
 
     private static final Logger logger = LoggerFactory.getLogger(DiversityObserver.class);
 
+    private static final long serialVersionUID = -3761776930918618235L;
+
     public DiversityObserver() {
         // empty default constructor
     }


### PR DESCRIPTION
Issue #29 made `SearchListener` serializable. However, some implementing subclasses do not have an explicit `serialVersionUID` declared. This PR would fix this problem.