### PR TITLE
Make SocketStoppingCondition a singleton

### DIFF
--- a/client/src/main/java/org/evosuite/ga/metaheuristics/TestSuiteAdapter.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/TestSuiteAdapter.java
@@ -500,6 +500,8 @@ public abstract class TestSuiteAdapter<A extends GeneticAlgorithm<TestChromosome
                 return;
             } else if (condition instanceof GlobalTimeStoppingCondition) {
                 adapteeCondition = new GlobalTimeStoppingCondition<>();
+            } else if (condition instanceof SocketStoppingCondition) {
+                adapteeCondition = SocketStoppingCondition.getInstance();
             } else {
                 throw new IllegalArgumentException("cannot adapt stopping condition " + condition);
             }

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/TestSuiteAdapter.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/TestSuiteAdapter.java
@@ -538,6 +538,8 @@ public abstract class TestSuiteAdapter<A extends GeneticAlgorithm<TestChromosome
             return RMIStoppingCondition.getInstance();
         } else if (stoppingCondition instanceof ShutdownTestWriter) {
             return new ShutdownTestWriter<>((ShutdownTestWriter<?>) stoppingCondition);
+        } else if (stoppingCondition instanceof SocketStoppingCondition) {
+            return SocketStoppingCondition.getInstance();
         } else {
             throw new IllegalArgumentException("cannot adapt stopping condition: " + stoppingCondition);
         }

--- a/client/src/main/java/org/evosuite/ga/stoppingconditions/RMIStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/ga/stoppingconditions/RMIStoppingCondition.java
@@ -36,11 +36,6 @@ public class RMIStoppingCondition<T extends Chromosome<T>> implements StoppingCo
 		// empty default constructor
 	}
 
-	@Override
-	public StoppingCondition<T> clone() {
-		throw new UnsupportedOperationException("cannot clone singleton");
-	}
-
 	@SuppressWarnings("unchecked")
 	public static <T extends Chromosome<T>> RMIStoppingCondition<T> getInstance() {
 		if (instance == null) {
@@ -50,6 +45,18 @@ public class RMIStoppingCondition<T extends Chromosome<T>> implements StoppingCo
 		// Cast always succeeds because RMIStoppingCondition doesn't actually do anything with a
 		// `T` instance.
 		return (RMIStoppingCondition<T>) instance;
+	}
+
+	/**
+	 * Always throws an {@code UnsupportedOperationException} when called. Singletons cannot be
+	 * cloned.
+	 *
+	 * @return never returns, always fails
+	 * @throws UnsupportedOperationException always
+	 */
+	@Override
+	public StoppingCondition<T> clone() throws UnsupportedOperationException {
+		throw new UnsupportedOperationException("cannot clone singleton");
 	}
 
 	public void stop() {

--- a/client/src/main/java/org/evosuite/ga/stoppingconditions/SocketStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/ga/stoppingconditions/SocketStoppingCondition.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SocketStoppingCondition<T extends Chromosome<T>> implements StoppingCondition<T> {
 
+	// There should only be one instance that opens the socket -> singleton design pattern
 	private static SocketStoppingCondition<?> instance = null;
 
 	private volatile boolean interrupted = false;

--- a/client/src/main/java/org/evosuite/ga/stoppingconditions/SocketStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/ga/stoppingconditions/SocketStoppingCondition.java
@@ -36,21 +36,37 @@ import org.slf4j.LoggerFactory;
  */
 public class SocketStoppingCondition<T extends Chromosome<T>> implements StoppingCondition<T> {
 
-	private volatile boolean interrupted;
+	private static SocketStoppingCondition<?> instance = null;
+
+	private volatile boolean interrupted = false;
 
 	private static final Logger logger = LoggerFactory.getLogger(SocketStoppingCondition.class);
 
-	public SocketStoppingCondition() {
-		this.interrupted = false;
+	private SocketStoppingCondition() {
+		// singleton pattern
 	}
 
-	public SocketStoppingCondition(SocketStoppingCondition<?> that) {
-		this.interrupted = that.interrupted;
+	@SuppressWarnings("unchecked")
+	public static <T extends Chromosome<T>> SocketStoppingCondition<T> getInstance() {
+		if (instance == null) {
+			instance = new SocketStoppingCondition<>();
+		}
+
+		// Unchecked cast always succeeds as long as we're not actually doing anything with a `T`
+		// instance.
+		return (SocketStoppingCondition<T>) instance;
 	}
 
+	/**
+	 * Always throws an {@code UnsupportedOperationException} when called. Singletons cannot be
+	 * cloned.
+	 *
+	 * @return never returns, always fails
+	 * @throws UnsupportedOperationException always
+	 */
 	@Override
-	public SocketStoppingCondition<T> clone() {
-		return new SocketStoppingCondition<>(this);
+	public StoppingCondition<T> clone() throws UnsupportedOperationException {
+		throw new UnsupportedOperationException("cannot clone singleton");
 	}
 
 	/**

--- a/client/src/main/java/org/evosuite/strategy/PropertiesMapElitesSearchFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesMapElitesSearchFactory.java
@@ -133,7 +133,7 @@ public class PropertiesMapElitesSearchFactory
       ga.addStoppingCondition(rmi);
 
       if (Properties.STOPPING_PORT != -1) {
-        SocketStoppingCondition<TestChromosome> ss = new SocketStoppingCondition<>();
+        SocketStoppingCondition<TestChromosome> ss = SocketStoppingCondition.getInstance();
         ss.accept();
         ga.addStoppingCondition(ss);
       }

--- a/client/src/main/java/org/evosuite/strategy/PropertiesNoveltySearchFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesNoveltySearchFactory.java
@@ -198,7 +198,7 @@ public class PropertiesNoveltySearchFactory extends PropertiesSearchAlgorithmFac
             ga.addStoppingCondition(rmi);
 
             if (Properties.STOPPING_PORT != -1) {
-                SocketStoppingCondition<TestChromosome> ss = new SocketStoppingCondition<>();
+                SocketStoppingCondition<TestChromosome> ss = SocketStoppingCondition.getInstance();
                 ss.accept();
                 ga.addStoppingCondition(ss);
             }

--- a/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
@@ -370,7 +370,8 @@ public class PropertiesSuiteGAFactory
 			ga.addStoppingCondition(rmi);
 
 			if (Properties.STOPPING_PORT != -1) {
-				SocketStoppingCondition<TestSuiteChromosome> ss = new SocketStoppingCondition<>();
+				SocketStoppingCondition<TestSuiteChromosome> ss =
+						SocketStoppingCondition.getInstance();
 				ss.accept();
 				ga.addStoppingCondition(ss);
 			}


### PR DESCRIPTION
In a [discussion](https://github.com/VoglSebastian/evosuite/pull/22#pullrequestreview-466786299) we had earlier, @VoglSebastian suggeseted the following:
> I am concerned about the SocketStoppingCondition, since only 1 instance can open the Socket in the accept method. We may add a static field boolean isStarted and make the field interrupted static as well.
> I don't think it was intended that there can be more than 1 instance of this class. Therefore, all instances should know when the search is interrupted.

I think he's right on his broader point that only one instance of `SocketStoppingCondition` should be able to open the socket. However, I disagree on the implementation details. I am in favor of turning `SocketStoppingCondition` into a singleton instead of allowing multiple instances with a shared static state. (Refer to the discussion in #22 and #23 for more details.)

This PR would implement the changes necessary to make `SocketStoppingCondition` a singleton.